### PR TITLE
Fixed broken setup script

### DIFF
--- a/run_bootstrap_first_then_pyjd_setup.py
+++ b/run_bootstrap_first_then_pyjd_setup.py
@@ -23,7 +23,7 @@ if __name__ == '__main__':
     setup(name = "Pyjamas Desktop",
         version = "0.8.1",
         description = "Pyjamas Widget API for Web applications, in Python",
-        long_description = open('README', 'rt').read(),
+        long_description = open('README.rst', 'rt').read(),
         url = "http://pyjs.org",
         author = "The Pyjamas Project",
         author_email = "lkcl@lkcl.net",


### PR DESCRIPTION
I was following the Getting Started instructions and discovered that the setup script was pointing to README instead of README.rst, causing an error.
