### PR TITLE
pyjscompressor multi-platform

### DIFF
--- a/contrib/pyjscompressor.py
+++ b/contrib/pyjscompressor.py
@@ -168,3 +168,4 @@ if __name__ == '__main__':
         dir = sys.argv[1]
         COMPILER = sys.argv[2]
         compress_all(dir)
+

--- a/contrib/pyjscompressor.py
+++ b/contrib/pyjscompressor.py
@@ -122,8 +122,7 @@ def compress(path):
     return (uncomp_type_size, uncomp_type_size)
 
 def getsize(path):
-    if os.path.isfile(path):
-        return os.path.getsize(path)
+    return os.path.getsize(path)
 
 def getcompression(p_size, n_size):
     return n_size / float(p_size) * 100

--- a/contrib/pyjscompressor.py
+++ b/contrib/pyjscompressor.py
@@ -1,18 +1,24 @@
 #!/usr/bin/env python
 # Copyright (C) 2010 Sujan Shakya, suzan.shakya@gmail.com
+#
+# This script works with the google closure compiler
+# http://closure-compiler.googlecode.com/files/compiler-latest.zip 
+#
+# The closure compiler requires java to be installed and an entry for your java directory in your system PATH
+# 
+# Set the COMPILER_PATH variable below to your google closure compiler.jar file
+# _or_ make sure to export COMPILER=/path/to/google/compiler
+#
+# Then run this script. This will reduce the output size to ~50%.
 
-# compile the pyjs application with 3 options. This will reduce the
-# output size to 85%.
+# To run type:
+# python pyjscompressor.py <path_to_your_pyjamas_output_directory>
+# from command line in the directory of this script
+import re, os, sys, shutil
 
-# pyjsbuild Hello.py --no-print-statements --no-bound-methods \
-#                    --no-operator-funcs
+#Set this string to the path to your compiler.jar
+COMPILER_PATH = r''
 
-# Make sure to export COMPILER=/path/to/google/compiler
-# Then run this script. This will reduce the output size to 50%.
-
-# pyjscompressor.py output
-
-import re, os, sys, commands
 
 MERGE_SCRIPTS = re.compile('</script>\s*(?:<!--.*?-->\s*)*<script(?:(?!\ssrc).)*?>', re.DOTALL)
 SCRIPT = re.compile('<script(?:(?!\ssrc).)*?>(.*?)</script>', re.DOTALL)
@@ -25,9 +31,9 @@ def compile(js_file, js_output_file, html_file=''):
     else:
         level = 'SIMPLE_OPTIMIZATIONS'
     stderr = '2> /dev/null' if os.name == 'posix' else ''
-    error = os.system('java -jar $COMPILER --compilation_level %s '
+    error = os.system('java -jar %s --compilation_level %s '
         ' --js %s --js_output_file %s %s' % \
-                (level, js_file, js_output_file, stderr))
+                (COMPILER_PATH, level, js_file, js_output_file, stderr))
     if error:
         raise Exception, 'Error occurred while compiling %s' % js_file
 
@@ -37,7 +43,6 @@ def compress_css(css_file):
     css_output_file = 'temp/%s.ccss' % os.path.basename(css_file)
     f = open(css_file)
     css = f.read()
-
     css = re.sub(r"\s+([!{};:>+\(\)\],])", r"\1", css)
     css = re.sub(r"([!{}:;>+\(\[,])\s+", r"\1", css)
     css = re.sub(r"\s+", " ", css)
@@ -45,20 +50,14 @@ def compress_css(css_file):
     f = open(css_output_file, 'w')
     f.write(css)
     f.close()
-    print '%4.1f%%' % getcompression(getsize(css_file),getsize(css_output_file))
-    os.rename(css_output_file, css_file)
-    os.system('rm -f temp/*')
+    return finish_compressors(css_output_file, css_file)
 
 def compress_js(js_file):
     sys.stdout.write('Compressing %-40s' % js_file)
     sys.stdout.flush()
     js_output_file = 'temp/%s.cjs' % os.path.basename(js_file)
-
     compile(js_file, js_output_file)
-
-    print '%4.1f%%' % getcompression(getsize(js_file), getsize(js_output_file))
-    os.rename(js_output_file, js_file)
-    os.system('rm -f temp/*')
+    return finish_compressors(js_output_file, js_file)
 
 def compress_html(html_file):
     sys.stdout.write('Compressing %-40s' % html_file)
@@ -100,64 +99,67 @@ def compress_html(html_file):
     f = open(html_output_file, 'w')
     f.write(html)
     f.close()
+    return finish_compressors(html_output_file, html_file)
 
-    print '%4.1f%%'%getcompression(getsize(html_file),getsize(html_output_file))
-    os.rename(html_output_file, html_file)
-    os.system('rm -f temp/*')
+def finish_compressors(new_path, old_path):
+    p_size, n_size = getsize(old_path),getsize(new_path)
+    os.remove(old_path)
+    os.rename(new_path, old_path)
+    print ' Ratio: %4.1f%%'% getcompression(p_size, n_size)
+    return p_size, n_size
 
 def compress(path):
     ext = os.path.splitext(path)[1]
     if ext == '.css':
-        compress_css(path)
+        return compress_css(path)
     elif ext == '.js':
-        compress_js(path)
+        return compress_js(path)
     elif ext == '.html':
-        compress_html(path)
+        return compress_html(path)
+    uncomp_type_size = getsize(path)
+    return (uncomp_type_size,uncomp_type_size)
 
 def getsize(path):
     if os.path.isfile(path):
         return os.path.getsize(path)
-    elif os.path.isdir(path):
-        output = commands.getoutput('du -s %s' % dir)
-        return int(output.split()[0]) * 1024
 
 def getcompression(p_size, n_size):
     return n_size / float(p_size) * 100
 
 def compress_all(path):
-    if not os.environ.has_key('COMPILER'):
-        sys.exit('environment variable COMPILER is not defined.\n'
-                 'In bash, export '
-                 'COMPILER=/home/me/google/compiler/compiler.jar')
-
     if not os.path.exists('temp'):
         os.makedirs('temp')
 
     print '%17s %45s' % ('Files', 'Compression')
-    p_size = getsize(path)
-
+    p_size = 0
+    n_size = 0
     if os.path.isfile(path):
-        compress(path)
+        p_size, n_size = compress(path)
     else:
         for root, dirs, files in os.walk(path):
             if 'temp' in root:
                 continue
             for file in files:
-                compress(os.path.join(root, file))
-        n_size = getsize(path)
-
-    n_size = getsize(path)
+                dp, dn = compress(os.path.join(root, file))
+                p_size += dp
+                n_size += dn
+    
     compression = getcompression(p_size, n_size)
+    shutil.rmtree("temp")
 
-    os.system('rm -rf temp')
     sizes = "Initial size: %.1fKB  Final size: %.1fKB" % \
             (p_size/1024., n_size/1024.)
     print '%s %s' % (sizes.ljust(51), "%4.1f%%" % compression)
 
 if __name__ == '__main__':
     if len(sys.argv) == 1:
-        print('usage python pyjs_compressor.py pyjamas_output_dir')
+        print('usage: python pyjs_compressor.py pyjamas_output_dir')
     else:
         dir = sys.argv[1]
+        if not COMPILER_PATH:
+            if not os.environ.has_key('COMPILER'):
+                sys.exit('environment variable COMPILER is not defined.\n'
+                 'In bash, export '
+                 'COMPILER=/home/me/google/compiler/compiler.jar or add the path to your compiler.jar at the top of this script.')
+            COMPILER_PATH = os.environ['COMPILER']
         compress_all(dir)
-


### PR DESCRIPTION
Replaced all specific OS commands with the general python lib versions
Works for me on windows now, should work elsewhere assuming these added python functions work there:
os.remove()
shutil.rmtree()
