### PR TITLE
Update library/pyjamas/History.ie6.py

### DIFF
--- a/library/pyjamas/History.ie6.py
+++ b/library/pyjamas/History.ie6.py
@@ -23,7 +23,7 @@ def init():
     if (tokenElement)
         $wnd['__historyToken'] = tokenElement['value'];
     else
-        historyFrame['src'] = "history['html']?" + $wnd['__historyToken'];
+        historyFrame['src'] = 'history.html?' + $wnd['__historyToken'];
 
     // Expose the '__onHistoryChanged' function, which will be called by
     // the history frame when it loads.
@@ -64,5 +64,5 @@ def init():
 def newItem(historyToken):
     JS("""
     var iframe = $doc['getElementById']('__pygwt_historyFrame');
-    iframe['contentWindow']['location']['href'] = "history['html']?" + @{{historyToken}};
+    iframe['contentWindow']['location']['href'] = 'history.html?' + @{{historyToken}};
     """)


### PR DESCRIPTION
Ok so the reason for those quote problems was an automated change from blah.blah to blah['blah'] so even though the quote revisions made the JS valid, this is what used to be here and what should still be here I think.
