### PR TITLE
Fix: ActiveX Error on IE9 

### DIFF
--- a/library/pyjamas/HTTPRequest.ie6.py
+++ b/library/pyjamas/HTTPRequest.ie6.py
@@ -1,5 +1,11 @@
 class HTTPRequest(object):
 
     def doCreateXmlHTTPRequest(self):
-        return JS("""new ActiveXObject("Msxml2['XMLHTTP']")""")
+        try:
+            return JS("""new ActiveXObject("Msxml2['XMLHTTP']")""")
+        except:
+            try:
+                return JS("""new ActiveXObject("Microsoft.XMLHTTP")""")
+            except:
+                return JS("""new window.XMLHttpRequest()""")
 


### PR DESCRIPTION
When trying to use JSONRPC, I was getting an error "Automation Server can't create an object." on IE9. Looking at library/dynamicajax.js, I added fallback options to library/pyjamas/HTTPRequest.ie6.py and that seems to have fixed the problem.
