### PR TITLE
[issue #771] Remove deprecated addition to sys.path

### DIFF
--- a/pyjd/__init__.py.in
+++ b/pyjd/__init__.py.in
@@ -17,8 +17,6 @@ _manager.set_runner()
 
 
 sys.path += [os.path.join(pyjdinitpth, 'library')]
-#TODO: this looks useless ...
-sys.path = [os.path.join(pyjdinitpth, 'pygtkweb', 'library')] + sys.path
 
 
 add_setup_callback = _manager.add_setup_listener


### PR DESCRIPTION
Pywebgtk hasn't worked for well over 2 years, remove unecessary modification to `sys.path`.
