### PR TITLE
replace Window.getDocumentRoot() override for safary

### DIFF
--- a/library/pyjamas/Window.safari.py
+++ b/library/pyjamas/Window.safari.py
@@ -1,9 +1,2 @@
 def getDocumentRoot():
-    # Safari does not implement $doc.compatMode.
-    # Use a CSS test to determine rendering mode.
-    JS("""
-        var elem = $doc['createElement']('div');
-        elem['style']['cssText'] = "width:0px;width:1";
-        return parseInt(elem['style']['width']) != 1 ? $doc['documentElement'] :
-                                                 $doc['body'];
-        """)
+    return doc().body


### PR DESCRIPTION
It looks like existing getDocumentRoot() override for safary does not work any more (tested on Chromium 21).
Replace it with just returning doc().body.
After this Window.getScrollTop() started to work again.
