### PR TITLE
HTML5 Text updates 

### DIFF
--- a/library/pyjamas/Canvas/HTML5Canvas.py
+++ b/library/pyjamas/Canvas/HTML5Canvas.py
@@ -110,6 +110,12 @@ class HTML5Canvas(GWTCanvas):
         return self.impl.getTextAlign()
 
     """
+    Returns the current text baseline settings
+    """
+    def getTextBaseline(self):
+        return self.impl.getTextBaseline()
+
+    """
     returns the current vertical shadow offset
     """
     def getShadowOffsetY(self):
@@ -140,3 +146,10 @@ class HTML5Canvas(GWTCanvas):
     """
     def setTextAlign(self, loc):
         self.impl.setTextAlign(loc)
+    
+    """
+    Sets the current text baseline settings. The possible values are alphabetic,
+    bottom, hanging, ideographic, middle, and top
+    """
+    def setTextBaseline(self, loc):
+        self.impl.setTextBaseline(loc)

--- a/library/pyjamas/Canvas/HTML5CanvasImplDefault.py
+++ b/library/pyjamas/Canvas/HTML5CanvasImplDefault.py
@@ -38,8 +38,11 @@ class HTML5CanvasImplDefault(GWTCanvasImplDefault):
         return self.canvasContext.shadowOffsetY
 
     def getTextAlign(self):
-        return self.impl.textAlign
-
+        return self.canvasContext.textAlign
+    
+    def getTextBaseline(self):
+        return self.canvasContext.textBaseline
+    
     def measureText(self, text):
         return self.canvasContext.measureText(text).width
 
@@ -60,7 +63,10 @@ class HTML5CanvasImplDefault(GWTCanvasImplDefault):
         self.canvasContext.shadowOffsetY = y
 
     def setTextAlign(self, loc):
-        self.impl.textAlign = loc
+        self.canvasContext.textAlign = loc
+    
+    def setTextBaseline(self, loc):
+        self.canvasContext.textBaseline = loc
 
     def toDataURL(self, type):
         return self.canvasContext.toDataURL(type)


### PR DESCRIPTION
The current HTML5 support for text properties is incomplete and broken.  This patch corrects the object reference (from impl to canvasContext) for textAlign, and adds support for textBaseline.

Note that there is a problem with HTML5Canvas.ie6.py - as distributed, an app using HTML5Canvas fails to complile with a missing LinearGradientIE6 reference - however, renaming this file to .pyq allows the build to complete and the apps work fine.  I don't understand the override system well enough to fix it :-(     and IE6 is a pretty pointless target in this case anyway.
