### PR TITLE
Canvas update

### DIFF
--- a/library/pyjamas/Canvas/GWTCanvasImplIE6.py
+++ b/library/pyjamas/Canvas/GWTCanvasImplIE6.py
@@ -661,16 +661,16 @@ class GWTCanvasImplIE6:
         self.pathStr.clear()
 
 
-    def transform(m11, m12, m21, m22, dx, dy):
+    def transform(self, m11, m12, m21, m22, dx, dy):
         a = self.matrix[0]
         b = self.matrix[1]
-        self.matrix[0] = a * m11 + b * m21
-        self.matrix[1] = a * m12 + b * m22
+        self.matrix[0] = a * m11 + b * m12
+        self.matrix[1] = a * m21 + b * m22
         self.matrix[2] += a * dx + b * dy
         a = self.matrix[3]
         b = self.matrix[4]
-        self.matrix[3] = a * m11 + b * m21
-        self.matrix[4] = a * m12 + b * m22
+        self.matrix[3] = a * m11 + b * m12
+        self.matrix[4] = a * m21 + b * m22
         self.matrix[5] += a * dx + b * dy
 
 

--- a/library/pyjamas/Canvas/HTML5Canvas.ie6.py
+++ b/library/pyjamas/Canvas/HTML5Canvas.ie6.py
@@ -1,10 +1,5 @@
-class HTML5Canvas(Widget):
+class HTML5Canvas(GWTCanvas):
 
     def getCanvasImpl(self):
         return HTML5CanvasImplIE6()
-    def createLinearGradient(self, x0, y0, x1, y1):
-        return LinearGradientImplIE6(x0, y0, x1, y1)# , self.getElement())
-    def createRadialGradient(self, x0, y0, r0, x1, y1, r1):
-        return RadialGradientImplIE6(x0, y0, r0, x1, y1, r1)#,self.getElement())
-
 

--- a/library/pyjamas/Canvas/HTML5Canvas.py
+++ b/library/pyjamas/Canvas/HTML5Canvas.py
@@ -7,6 +7,7 @@ Created on Sun Nov 28 19:22:15 2010
 
 from pyjamas.Canvas.GWTCanvas import GWTCanvas
 from pyjamas.Canvas.HTML5CanvasImplDefault import HTML5CanvasImplDefault
+from pyjamas.Canvas.HTML5CanvasImplIE6 import HTML5CanvasImplIE6
 from pyjamas.Canvas.Color import Color
 from pyjamas.Canvas.ImageData import ImageData
 

--- a/library/pyjamas/Canvas/HTML5CanvasImplIE6.py
+++ b/library/pyjamas/Canvas/HTML5CanvasImplIE6.py
@@ -45,6 +45,9 @@ class HTML5CanvasImplIE6(GWTCanvasImplIE6):
     def getTextAlign(self):
         raise NotImplementedError
 
+    def getTextBaseline(self):
+        raise NotImplementedError
+
     def measureText(self, text):
         raise NotImplementedError
 
@@ -64,6 +67,9 @@ class HTML5CanvasImplIE6(GWTCanvasImplIE6):
         raise NotImplementedError
 
     def setTextAlign(self, loc):
+        raise NotImplementedError
+
+    def setTextBaseline(self, loc):
         raise NotImplementedError
 
     def toDataURL(self, type):


### PR DESCRIPTION
These commits impact Canvas functions affecting mainly ie6/7/8, merge if support for these is maintained. Two commits relate to https://github.com/pyjs/pyjs/pull/788, changed HTML5Canvas to correct translator failure and added necessary methods to HTML5CanvasImplIE6. Stumbled across errors in transform method of GWTCanvasImplIE6, changed to make it functional and for proper transformation. Following changes, programs using these functions ran properly in firefox v21 and ie6.
