### PR TITLE
Tentative IE11 user-agent detection

### DIFF
--- a/builder/boilerplate/home.nocache.html
+++ b/builder/boilerplate/home.nocache.html
@@ -17,13 +17,7 @@ window["provider$user.agent"] = function() {
    else if (ua.indexOf('msie7.0') != -1) {
     return 'ie6';
   }
-   else if (ua.indexOf('msie 8.0') != -1) {
-    return 'ie6';
-  }
-   else if (ua.indexOf('msie 9.0') != -1) {
-    return 'ie6';
-  }
-   else if (ua.indexOf('msie 10.0')) != -1 {
+   else if (ua.indexOf('trident')) != -1 {
     return 'ie6';
   }
    else if (ua.indexOf('mozilla') != -1) {

--- a/pyjs/src/pyjs/boilerplate/home.nocache.html
+++ b/pyjs/src/pyjs/boilerplate/home.nocache.html
@@ -20,13 +20,7 @@ window["provider$user.agent"] = function() {
    else if (ua.indexOf('msie7.0') != -1) {
     return 'ie6';
   }
-   else if (ua.indexOf('msie 8.0') != -1) {
-    return 'ie6';
-  }
-   else if (ua.indexOf('msie 9.0') != -1) {
-    return 'ie6';
-  }
-   else if (ua.indexOf('msie 10.0') != -1) {
+   else if (ua.indexOf('trident') != -1) {
     return 'ie6';
   }
    else if (ua.indexOf('mozilla') != -1) {


### PR DESCRIPTION
For reference:

http://msdn.microsoft.com/fr-fr/library/ie/bg182625%28v=vs.85%29.aspx#uaString 

The changes should bring the additional benefit of simplifying a wee bit the detection of less ancient versions of IE, as from IE 8 on, all bear "Trident" in the user-agent string .

_**WARNING_*

This is still untested code!
