### PR TITLE
Fix remote code execution vulnerability

### DIFF
--- a/pyjs/jsonrpc/cgihandler/__init__.py
+++ b/pyjs/jsonrpc/cgihandler/__init__.py
@@ -55,7 +55,7 @@ class CGIJSONRPCService(JSONRPCServiceBase):
         self._cookies = c
 
     def __call__(self):
-        self._cookies = Cookie.SmartCookie()
+        self._cookies = Cookie.SimpleCookie()
         self._cookies.load(os.environ.get('HTTP_COOKIE', ''))
         d = read_data() # TODO: handle partial data
         write_data(self.process(d), self._cookies.output())


### PR DESCRIPTION
SmartCookie as well as SerialCookie are vulnerable to code injection in python2.
For example, the following cookie header would shutdown your server:
Set-Cookie: foo="cposix\012_exit\012p1\012(I1\012tp2\012Rp3\012."
