### PR TITLE
Fix for Pyjscompressor on Windows

### DIFF
--- a/pyjs/contrib/pyjscompressor.py
+++ b/pyjs/contrib/pyjscompressor.py
@@ -149,7 +149,7 @@ def finish_compressors(new_path, old_path):
 
 def compress(path):
     try:
-        ext = os.path.splitext(path)[1]
+        ext = os.path.splitext(path)[-1]
         if ext == '.css':
             return compress_css(path)
         elif ext == '.js':
@@ -221,7 +221,8 @@ def compress_all(path, exts):
         files_to_compress = []
         for root, dirs, files in os.walk(path):
             for file in files:
-                ext = '.' + file.split('.')[1]
+                ext = '.' + file.split('.')[-1]
+                print ext
                 if exts:
                     if ext in exts:# only allow matching extensions
                         files_to_compress.append(os.path.join(root, file))


### PR DESCRIPTION
pyjscompressor was not working on Windows.  Function has been modified so that temp files are tracked and deleted at the end. Created override function NamedTemporaryFile to handle different platforms.  I also added -a option so that only specific file types will be compressed.

These change have been working great for me on windows.  Would like someone to try on different platforms.
