### PR TITLE
Unicode Error In Logging Module on Windows

### DIFF
--- a/pyjs/lib/logging/__init__.py
+++ b/pyjs/lib/logging/__init__.py
@@ -48,7 +48,7 @@ __date__    = "16 February 2007"
 # caller stack frame.
 #
 _srcfile = __file__
-#_srcfile = os.path.normcase(_srcfile)
+_srcfile = os.path.normcase(_srcfile)
 
 # next bit filched from 1.5.2's inspect.py
 def currentframe():


### PR DESCRIPTION
There was a line of code that was commented out that fixes paths for windows.  Has not impact on MAC or UNIX.  When enabled, my unicode error went away.  Simple fix.