### PR TITLE
docs: Fix a few typos

### DIFF
--- a/examples/misc/djangotasks/media/TodoApp.py
+++ b/examples/misc/djangotasks/media/TodoApp.py
@@ -40,7 +40,7 @@ class TodoApp:
 
     def onKeyPress(self, sender, keyCode, modifiers):
         """
-        This functon handles the onKeyPress event, and will add the item in the text box to the list when the user presses the enter key.  In the future, this method will also handle the auto complete feature.
+        This function handles the onKeyPress event, and will add the item in the text box to the list when the user presses the enter key.  In the future, this method will also handle the auto complete feature.
         """
         if keyCode == KeyboardListener.KEY_ENTER and sender == self.todoTextBox:
             id = self.remote.addTask(sender.getText(),self)

--- a/examples/misc/djangowanted/media/WebPageEdit.py
+++ b/examples/misc/djangowanted/media/WebPageEdit.py
@@ -70,7 +70,7 @@ class WebPageEdit(Composite):
 
     def onKeyPress(self, sender, keyCode, modifiers):
         """
-        This functon handles the onKeyPress event, and will add the item in the text box to the list when the user presses the enter key.  In the future, this method will also handle the auto complete feature.
+        This function handles the onKeyPress event, and will add the item in the text box to the list when the user presses the enter key.  In the future, this method will also handle the auto complete feature.
         """
         pass
 

--- a/examples/misc/djangoweb/media/WebPageEdit.py
+++ b/examples/misc/djangoweb/media/WebPageEdit.py
@@ -73,7 +73,7 @@ class WebPageEdit(Composite):
 
     def onKeyPress(self, sender, keyCode, modifiers):
         """
-        This functon handles the onKeyPress event, and will add the item in the text box to the list when the user presses the enter key.  In the future, this method will also handle the auto complete feature.
+        This function handles the onKeyPress event, and will add the item in the text box to the list when the user presses the enter key.  In the future, this method will also handle the auto complete feature.
         """
         pass
 

--- a/examples/misc/flaskexamples/doc/index.rst
+++ b/examples/misc/flaskexamples/doc/index.rst
@@ -169,7 +169,7 @@ More Fun with Asynchronicity
 ============================
 
 By using Pyjamas, Flask, and Celery we can have multiple levels of 
-asynchonicity.  There is an included example that shows how one can use
+asynchronicity.  There is an included example that shows how one can use
 JSON-RPC from a pyjamas application to initiate an asynchonous job on 
 a Flask server.  Since we are using RabbitMQ, we can off-load the 
 resource intensive RPC requests to machines other than the webserver.  

--- a/examples/timesheet/libtimesheet/view/components/TimeGrid.py
+++ b/examples/timesheet/libtimesheet/view/components/TimeGrid.py
@@ -99,7 +99,7 @@ class TimeGrid(FlexTable):
             self.currentCol = col
             self.getWidget(self.currentRow, self.currentCol).setFocus(True)
             return
-        # Now we're moving to new postition, just make sure
+        # Now we're moving to new position, just make sure
         # that the previous cells are filled in correctly
         if not self.checkCell(self.currentRow, self.currentCol, True):
             # Nope. We won't move

--- a/examples/toggle/Toggle.py
+++ b/examples/toggle/Toggle.py
@@ -1,4 +1,4 @@
-""" testint our demo slider
+""" testing our demo slider
 """
 import pyjd # dummy in pyjs
 

--- a/pyjs/builtin/pyjslib.py
+++ b/pyjs/builtin/pyjslib.py
@@ -7694,7 +7694,7 @@ class Formatter(BaseFormatter):
             out.append(num[to_remainder:])
         if spec.n_rpadding:
             out.append_multiple_char(fill_char[0], spec.n_rpadding)
-        #if complex, need to call twice - just retun the buffer
+        #if complex, need to call twice - just return the buffer
         return out.build()
 
     def _format_int_or_long(self, w_num, kind):

--- a/pyjswidgets/dynamic.py
+++ b/pyjswidgets/dynamic.py
@@ -31,7 +31,7 @@ def createHttpRequest():
 #
 #  @param url                   URL to load
 #  @param onreadystatechange    function to be used for onreadystatechange
-#  @param on_load_fn            function to be called on succes, with parameters event, request
+#  @param on_load_fn            function to be called on success, with parameters event, request
 #  @param async                 request mode
 #  @returns                     async == False: request object, async == True: None
 #

--- a/pyjswidgets/pyjamas/Timer.py
+++ b/pyjswidgets/pyjamas/Timer.py
@@ -135,7 +135,7 @@ class Timer(object):
         The method that gets fired when the timer goes off.
         The base class raises a NotImplementedError if it is not
         overridden by a subclass or if Timer isn't instantiated with
-        the notify keyword arguement.
+        the notify keyword argument.
         """
         raise NotImplementedError, ('''Timer.run() must be overridden or Timer
                                        must be instantiated with notify keyword

--- a/pyjswidgets/pyjamas/chart/GChart.py
+++ b/pyjswidgets/pyjamas/chart/GChart.py
@@ -3825,7 +3825,7 @@ class GChart (Composite, FocusHandler, KeyboardHandler,
     * tests) when the canvas is re-inserted into the DOM.
     *
     * See TestGChart55.java and TestGChart55a.java for more
-    * info on the GWTCanvas bug that makes this code neccessary.
+    * info on the GWTCanvas bug that makes this code necessary.
     *
     * TODO: Implement technique of GWTCanvasIssue293.patch to
     * override removeFromParent and store/restore innerHTML


### PR DESCRIPTION
There are small typos in:
- examples/misc/djangotasks/media/TodoApp.py
- examples/misc/djangowanted/media/WebPageEdit.py
- examples/misc/djangoweb/media/WebPageEdit.py
- examples/misc/flaskexamples/doc/index.rst
- examples/timesheet/libtimesheet/view/components/TimeGrid.py
- examples/toggle/Toggle.py
- pyjs/builtin/pyjslib.py
- pyjswidgets/dynamic.py
- pyjswidgets/pyjamas/Timer.py
- pyjswidgets/pyjamas/chart/GChart.py

Fixes:
- Should read `function` rather than `functon`.
- Should read `testing` rather than `testint`.
- Should read `success` rather than `succes`.
- Should read `return` rather than `retun`.
- Should read `position` rather than `postition`.
- Should read `necessary` rather than `neccessary`.
- Should read `asynchronicity` rather than `asynchonicity`.
- Should read `argument` rather than `arguement`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md